### PR TITLE
Add Support for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,10 @@ lazy val root = (project in file(".")).
     organization := "com.tsukaby",
     name := "naive-bayes-classifier-scala",
     version := "0.2.0",
-    scalaVersion := "2.12.4",
-    crossScalaVersions := Seq("2.11.12", "2.12.4"),
+    scalaVersion := "2.13.5",
+    crossScalaVersions := Seq("2.11.12", "2.12.13", "2.13.5"),
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2-core" % "4.0.1" % "test"
+      "org.specs2" %% "specs2-core" % "4.5.1" % "test"
     ),
     // Maven deploy settings
     publishMavenStyle := true,
@@ -49,7 +49,6 @@ lazy val root = (project in file(".")).
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-unused",
-      "-Ywarn-unused-import",
       "-Ywarn-value-discard",
       "-Xfatal-warnings",
       "-Yrangepos"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/scala/com/tsukaby/bayes/classifier/BayesClassifier.scala
+++ b/src/main/scala/com/tsukaby/bayes/classifier/BayesClassifier.scala
@@ -18,7 +18,7 @@ class BayesClassifier[T, K <: AnyRef] extends Classifier[T, K] {
    * @param category The category to test for.
    * @return The product of all feature probabilities.
    */
-  private def featuresProbabilityProduct(features: Traversable[T], category: K): Float = {
+  private def featuresProbabilityProduct(features: Iterable[T], category: K): Float = {
     features.foldLeft(1.0f)((x: Float, y: T) => x * featureWeighedAverage(y, category))
   }
 
@@ -29,7 +29,7 @@ class BayesClassifier[T, K <: AnyRef] extends Classifier[T, K] {
    * @param category The category to test for.
    * @return The probability that the features can be classified as the category.
    */
-  private def categoryProbability(features: Traversable[T], category: K): Float = {
+  private def categoryProbability(features: Iterable[T], category: K): Float = {
     (categoryCount(category).toFloat / categoriesTotal.toFloat) * featuresProbabilityProduct(features, category)
   }
 
@@ -49,7 +49,7 @@ class BayesClassifier[T, K <: AnyRef] extends Classifier[T, K] {
    * @param features The set of features to use.
    * @return A sorted <code>Set</code> of category-probability-entries.
    */
-  private def categoryProbabilities(features: Traversable[T]): mutable.SortedSet[Classification[T, K]] = {
+  private def categoryProbabilities(features: Iterable[T]): mutable.SortedSet[Classification[T, K]] = {
     val probabilities: mutable.SortedSet[Classification[T, K]] = mutable.TreeSet.empty[Classification[T, K]](ordering)
 
     for (category <- categories) {
@@ -63,7 +63,7 @@ class BayesClassifier[T, K <: AnyRef] extends Classifier[T, K] {
    *
    * @return The category the set of features is classified as.
    */
-  override def classify(features: Traversable[T]): Option[Classification[T, K]] = {
+  override def classify(features: Iterable[T]): Option[Classification[T, K]] = {
     val probabilities: SortedSet[Classification[T, K]] = categoryProbabilities(features)
     probabilities.lastOption
   }
@@ -74,7 +74,7 @@ class BayesClassifier[T, K <: AnyRef] extends Classifier[T, K] {
    *
    * @return The set of categories the set of features is classified as.
    */
-  def classifyDetailed(features: Traversable[T]): Traversable[Classification[T, K]] = {
+  def classifyDetailed(features: Iterable[T]): Iterable[Classification[T, K]] = {
     categoryProbabilities(features)
   }
 }

--- a/src/main/scala/com/tsukaby/bayes/classifier/Classification.scala
+++ b/src/main/scala/com/tsukaby/bayes/classifier/Classification.scala
@@ -5,7 +5,7 @@ package com.tsukaby.bayes.classifier
  *
  */
 case class Classification[T, K <: AnyRef](
-  features: Traversable[T],
+  features: Iterable[T],
   category: K,
   probability: Float = 0.0f
 )

--- a/src/main/scala/com/tsukaby/bayes/classifier/Classifier.scala
+++ b/src/main/scala/com/tsukaby/bayes/classifier/Classifier.scala
@@ -223,7 +223,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    * @param category The category the features belong to.
    * @param features The features that resulted in the given category.
    */
-  def learn(category: K, features: Traversable[T]): Unit = {
+  def learn(category: K, features: Iterable[T]): Unit = {
     learn(Classification[T, K](features, category))
   }
 
@@ -251,5 +251,5 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    * @param features The features to classify.
    * @return The category most likely.
    */
-  def classify(features: Traversable[T]): Option[Classification[T, K]]
+  def classify(features: Iterable[T]): Option[Classification[T, K]]
 }

--- a/src/main/scala/com/tsukaby/bayes/classifier/Classifier.scala
+++ b/src/main/scala/com/tsukaby/bayes/classifier/Classifier.scala
@@ -54,7 +54,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    *
    * @param memoryCapacity The new memory capacity.
    */
-  def setMemoryCapacity(memoryCapacity: Int) {
+  def setMemoryCapacity(memoryCapacity: Int): Unit = {
     var i: Int = memoryCapacity
     while (i > memoryCapacity && memoryQueue.nonEmpty) {
       memoryQueue.dequeue()
@@ -71,7 +71,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    * @param feature The feature, which count to increase.
    * @param category The category the feature occurred in.
    */
-  def incrementFeature(feature: T, category: K) {
+  def incrementFeature(feature: T, category: K): Unit = {
     val features: mutable.Map[T, Int] = featureCountPerCategory.getOrElse(category, {
       val newMap = mutable.Map[T, Int]()
       featureCountPerCategory.put(category, newMap)
@@ -88,7 +88,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    *
    * @param category The category, which count to increase.
    */
-  def incrementCategory(category: K) {
+  def incrementCategory(category: K): Unit = {
     totalCategoryCount.update(category, totalCategoryCount.getOrElse(category, 0) + 1)
   }
 
@@ -100,7 +100,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    * @param feature The feature to decrement the count for.
    * @param category The category.
    */
-  def decrementFeature(feature: T, category: K) {
+  def decrementFeature(feature: T, category: K): Unit = {
 
     for {
       features <- featureCountPerCategory.get(category)
@@ -133,7 +133,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    *
    * @param category The category, which count to increase.
    */
-  def decrementCategory(category: K) {
+  def decrementCategory(category: K): Unit = {
     for {
       count <- totalCategoryCount.get(category)
     } {
@@ -223,7 +223,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    * @param category The category the features belong to.
    * @param features The features that resulted in the given category.
    */
-  def learn(category: K, features: Traversable[T]) {
+  def learn(category: K, features: Traversable[T]): Unit = {
     learn(Classification[T, K](features, category))
   }
 
@@ -233,7 +233,7 @@ abstract class Classifier[T, K <: AnyRef] extends IFeatureProbability[T, K] {
    *
    * @param classification The classification to learn.
    */
-  def learn(classification: Classification[T, K]) {
+  def learn(classification: Classification[T, K]): Unit = {
     for (feature <- classification.features) incrementFeature(feature, classification.category)
     incrementCategory(classification.category)
     memoryQueue.enqueue(classification)


### PR DESCRIPTION
This is bumping a couple of dependencies and adds  2.13 as target version.

I had to make a couple of adjustments to ensure that it is not relying on deprecated features.
I also had to drop checking for unused imports because the compiler parameter changed between versions.